### PR TITLE
Network Settings update

### DIFF
--- a/biglobby_tweak.xml
+++ b/biglobby_tweak.xml
@@ -148,6 +148,11 @@
 				<param type="bool" />                   <!-- create body bag -->
 				<param type="int" min="1" max="128" />  <!-- peer_id -->
 			</message>
+			
+			<message name="biglobby__mission_ended" delivery="ordered" receiver="biglobby__unit" check="server_to_client">
+				<param type="bool" />	<!-- win -->
+				<param type="int" min="0" max="128" /> <!-- num_is_inside -->
+			</message>
 
 			<message name="biglobby__sync_trip_mine_setup" delivery="ordered" receiver="biglobby__unit" check="server_to_client">
 				<param type="unit" />
@@ -184,7 +189,7 @@
 
 			<message name="biglobby__sync_grenades" delivery="ordered" receiver="biglobby__unit">
 				<param type="string" />                <!-- Grenade id -->
-				<param type="int" min="0" max="31" />  <!-- Amount of grenades  -->
+				<param type="int" min="0" max="63" />  <!-- Amount of grenades  -->
 				<param type="int" min="0" max="128" /> <!-- Peer id -->
 			</message>
 

--- a/lua/_custom/biglobby_globals.lua
+++ b/lua/_custom/biglobby_globals.lua
@@ -97,6 +97,7 @@ if not _G.BigLobbyGlobals then
 	local unit_network_handler_funcs = {
 		'set_unit',
 		'remove_corpse_by_id',
+		'mission_ended',
 		'sync_trip_mine_setup',
 		'from_server_sentry_gun_place_result',
 		'sync_equipment_setup',


### PR DESCRIPTION
mission_ended seems to be related to how many people are in the escape zone on mission end.

The grenades amount in vanilla network settings was upped to 63 from 31.