### PR TITLE
Updated Network session states functions & achievement

### DIFF
--- a/lua/lib/managers/_achievementmanager.lua
+++ b/lua/lib/managers/_achievementmanager.lua
@@ -13,7 +13,7 @@ function AchievmentManager:disable_achievements()
 	-- be able to unlock achievements while not in a game and have the mod enabled
 	local m_session = managers.network:session()
 
-	local isRegularAmount = m_session and (m_session:amount_of_players() <= 4)
+	local isRegularAmount = m_session and (m_session:amount_of_players() > 4)
 	local isRegularSize   = m_session and BigLobbyGlobals:is_small_lobby()
 
 	return isRegularAmount or isRegularSize

--- a/lua/lib/network/base/session_states/_hoststateingame.lua
+++ b/lua/lib/network/base/session_states/_hoststateingame.lua
@@ -1,16 +1,49 @@
 -- Unfortunately no clean way to modify this bit of code, so I have to include the
 -- original code with modified, could cause problems with other mods that would want to touch this function
-function HostStateInGame:on_join_request_received(data, peer_name, client_preferred_character, dlcs, xuid, peer_level, peer_rank, peer_stinger_index, gameversion, join_attempt_identifier, auth_ticket, sender)
-	
+
+function HostStateInGame:on_join_request_received(data, peer_name, peer_account_type_str, peer_account_id, client_preferred_character, dlcs, xuid, peer_level, peer_rank, peer_stinger_index, gameversion, join_attempt_identifier, auth_ticket, sender)
+
+	-- Number of players allowed to join the game(excluding the host)
 	local num_player_slots = BigLobbyGlobals:num_player_slots() - 1
 	
 	-- Original Code --
-	print("[HostStateInGame:on_join_request_received]", data, peer_name, client_preferred_character, dlcs, xuid, peer_level, gameversion, join_attempt_identifier, sender:ip_at_index(0))
+	print("[HostStateInGame:on_join_request_received]", data, peer_name, peer_account_type_str, peer_account_id, client_preferred_character, dlcs, xuid, peer_level, gameversion, join_attempt_identifier, sender:ip_at_index(0))
 
+	local peer_id = sender:ip_at_index(0)
 	local my_user_id = data.local_peer:user_id() or ""
+	local drop_in_name = peer_name
 
-	if SystemInfo:platform() == Idstring("WIN32") then
-		peer_name = managers.network.account:username_by_id(sender:ip_at_index(0))
+	if peer_account_type_str == "STEAM" then
+		local temp = peer_name
+
+		if SystemInfo:distribution() == Idstring("STEAM") then
+			peer_name = managers.network.account:username_by_id(peer_account_id)
+		elseif SystemInfo:matchmaking() == Idstring("MM_STEAM") then
+			peer_name = managers.network.matchmake:username_by_id(peer_account_id)
+		end
+
+		if peer_name == "" or peer_name == "[unknown]" then
+			peer_name = temp
+		end
+	end
+
+	if SocialHubFriends:is_blocked(peer_id) then
+		self:_send_request_denied(sender, 0, my_user_id)
+
+		return
+	end
+
+	if managers.network.matchmake:get_lobby_type() == "friend" then
+		print("[HostStateInGame:on_join_request_received] lobby type friend only, check if friend")
+
+		if SocialHubFriends:is_friend_global(peer_id, peer_account_type_str, peer_account_id) then
+			print("[HostStateInGame:on_join_request_received] ok we are friend with ", peer_name)
+		else
+			print("[HostStateInGame:on_join_request_received] we are NOT friend with ", peer_name, " deny request")
+			self:_send_request_denied(sender, 0, my_user_id)
+
+			return
+		end
 	end
 
 	if self:_has_peer_left_PSN(peer_name) then
@@ -29,7 +62,7 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 		self:_send_request_denied(sender, 0, my_user_id)
 
 		return
-	elseif self:_is_banned(peer_name, sender) then
+	elseif self:_is_banned(peer_name, peer_account_id) then
 		self:_send_request_denied(sender, 9, my_user_id)
 
 		return
@@ -49,10 +82,19 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 		self:_send_request_denied(sender, 0, my_user_id)
 
 		return
-	else
-		local user = Steam:user(sender:ip_at_index(0))
+	elseif not MenuCallbackHandler:is_modded_client() and not Global.game_settings.allow_modded_players then
+		local is_modded = false
 
-		if not MenuCallbackHandler:is_modded_client() and not Global.game_settings.allow_modded_players and user and user:rich_presence("is_modded") == "1" then
+		if SystemInfo:distribution() == Idstring("STEAM") and peer_account_type_str == "STEAM" then
+			local user = Steam:user(sender:ip_at_index(0))
+			is_modded = user:rich_presence("is_modded") == "1"
+		end
+
+		if SystemInfo:distribution() == Idstring("EPIC") and peer_account_type_str == "EPIC" then
+			-- Nothing
+		end
+
+		if is_modded then
 			self:_send_request_denied(sender, 10, my_user_id)
 
 			return
@@ -63,18 +105,19 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 
 	if old_peer then
 		if join_attempt_identifier ~= old_peer:join_attempt_identifier() then
-			data.session:remove_peer(old_peer, old_peer:id(), "lost")
 			self:_send_request_denied(sender, 0, my_user_id)
+			data.session:remove_peer(old_peer, old_peer:id(), "lost")
 		end
 
 		return
 	end
-	-- End Original Code -
+	-- End Original Code --
 
 	-- num_player_slots variable instead of hardcoded 3, removes enforced limit.
 	if num_player_slots <= table.size(data.peers) then
 		print("server is full")
 		self:_send_request_denied(sender, 5, my_user_id)
+
 		return
 	end
 
@@ -87,7 +130,7 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 	end
 
 	local new_peer_id, new_peer = nil
-	new_peer_id, new_peer = data.session:add_peer(peer_name, nil, false, false, false, nil, character, sender:ip_at_index(0), xuid, xnaddr)
+	new_peer_id, new_peer = data.session:add_peer(peer_name, nil, false, false, false, nil, character, sender:ip_at_index(0), peer_account_type_str, peer_account_id, xuid, xnaddr)
 
 	if not new_peer_id then
 		print("there was no clean peer_id")
@@ -98,18 +141,24 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 
 	new_peer:set_dlcs(dlcs)
 	new_peer:set_xuid(xuid)
+	new_peer:set_name_drop_in(drop_in_name)
 	new_peer:set_join_attempt_identifier(join_attempt_identifier)
 
 	local new_peer_rpc = nil
-	new_peer_rpc = managers.network:protocol_type() == "TCP_IP" and managers.network:session():resolve_new_peer_rpc(new_peer, sender) or sender
+
+	if sender:protocol_at_index(0) == "TCP_IP" then
+		new_peer_rpc = managers.network:session():resolve_new_peer_rpc(new_peer, sender)
+	else
+		new_peer_rpc = sender
+	end
 
 	new_peer:set_rpc(new_peer_rpc)
 	new_peer:set_ip_verified(true)
 	Network:add_co_client(new_peer_rpc)
 
 	if not new_peer:begin_ticket_session(auth_ticket) then
-		data.session:remove_peer(new_peer, new_peer:id(), "auth_fail")
 		self:_send_request_denied(sender, 8, my_user_id)
+		data.session:remove_peer(new_peer, new_peer:id(), "auth_fail")
 
 		return
 	end
@@ -155,7 +204,6 @@ function HostStateInGame:on_join_request_received(data, peer_name, client_prefer
 	}
 
 	new_peer:send("join_request_reply", unpack(params))
-	
 	-- Original Code --
 	new_peer:send("set_loading_state", false, data.session:load_counter())
 

--- a/lua/lib/network/base/session_states/_hoststateinlobby.lua
+++ b/lua/lib/network/base/session_states/_hoststateinlobby.lua
@@ -1,15 +1,48 @@
 -- Unfortunately no clean way to modify this bit of code, so I have to include the
 -- original code with modified, could cause problems with other mods that would want to touch this function
-function HostStateInLobby:on_join_request_received(data, peer_name, client_preferred_character, dlcs, xuid, peer_level, peer_rank, peer_stinger_index, gameversion, join_attempt_identifier, auth_ticket, sender)
-	
+function HostStateInLobby:on_join_request_received(data, peer_name, peer_account_type_str, peer_account_id, client_preferred_character, dlcs, xuid, peer_level, peer_rank, peer_stinger_index, gameversion, join_attempt_identifier, auth_ticket, sender)
+	print("[HostStateInLobby:on_join_request_received]", data, peer_name, peer_account_type_str, peer_account_id, client_preferred_character, dlcs, xuid, peer_level, peer_rank, peer_stinger_index, gameversion, join_attempt_identifier, auth_ticket, sender:ip_at_index(0))
+
 	-- Number of players allowed to join the game(excluding the host)
 	local num_player_slots = BigLobbyGlobals:num_player_slots() - 1
 	
 	-- Original Code --
-	print("HostStateInLobby:on_join_request_received peer_level", peer_level, join_attempt_identifier, gameversion)
+	local peer_id = sender:ip_at_index(0)
+	local drop_in_name = peer_name
 
-	if SystemInfo:platform() == Idstring("WIN32") then
-		peer_name = managers.network.account:username_by_id(sender:ip_at_index(0))
+	if peer_account_type_str == "STEAM" then
+		local temp = peer_name
+
+		if SystemInfo:distribution() == Idstring("STEAM") then
+			peer_name = managers.network.account:username_by_id(peer_account_id)
+		elseif SystemInfo:matchmaking() == Idstring("MM_STEAM") then
+			peer_name = managers.network.matchmake:username_by_id(peer_account_id)
+		end
+
+		if peer_name == "" or peer_name == "[unknown]" then
+			peer_name = temp
+		end
+	end
+
+	local my_user_id = data.local_peer:user_id() or ""
+
+	if SocialHubFriends:is_blocked(peer_id) then
+		self:_send_request_denied(sender, 0, my_user_id)
+
+		return
+	end
+
+	if managers.network.matchmake:get_lobby_type() == "friend" then
+		print("[HostStateInLobby:on_join_request_received] lobby type friend only, check if friend")
+
+		if SocialHubFriends:is_friend_global(peer_id, peer_account_type_str, peer_account_id) then
+			print("[HostStateInLobby:on_join_request_received] ok we are friend with ", peer_name)
+		else
+			print("[HostStateInLobby:on_join_request_received] we are NOT friend with ", peer_name, " deny request")
+			self:_send_request_denied(sender, 0, my_user_id)
+
+			return
+		end
 	end
 
 	if self:_has_peer_left_PSN(peer_name) then
@@ -18,20 +51,29 @@ function HostStateInLobby:on_join_request_received(data, peer_name, client_prefe
 		return
 	end
 
-	local my_user_id = data.local_peer:user_id() or ""
-
-	if self:_is_banned(peer_name, sender) then
+	if self:_is_banned(peer_name, peer_account_id) then
 		self:_send_request_denied(sender, 9, my_user_id)
 
 		return
 	end
 
-	local user = Steam:user(sender:ip_at_index(0))
+	if not MenuCallbackHandler:is_modded_client() and not Global.game_settings.allow_modded_players then
+		local is_modded = false
 
-	if not MenuCallbackHandler:is_modded_client() and not Global.game_settings.allow_modded_players and user and user:rich_presence("is_modded") == "1" then
-		self:_send_request_denied(sender, 10, my_user_id)
+		if SystemInfo:distribution() == Idstring("STEAM") and peer_account_type_str == "STEAM" then
+			local user = Steam:user(sender:ip_at_index(0))
+			is_modded = user:rich_presence("is_modded") == "1"
+		end
 
-		return
+		if SystemInfo:distribution() == Idstring("EPIC") and peer_account_type_str == "EPIC" then
+			-- Nothing
+		end
+
+		if is_modded then
+			self:_send_request_denied(sender, 10, my_user_id)
+
+			return
+		end
 	end
 
 	if peer_level < Global.game_settings.reputation_permission then
@@ -62,8 +104,8 @@ function HostStateInLobby:on_join_request_received(data, peer_name, client_prefe
 
 	if old_peer then
 		if join_attempt_identifier ~= old_peer:join_attempt_identifier() then
-			data.session:remove_peer(old_peer, old_peer:id(), "lost")
 			self:_send_request_denied(sender, 0, my_user_id)
+			data.session:remove_peer(old_peer, old_peer:id(), "lost")
 		end
 
 		return
@@ -74,6 +116,7 @@ function HostStateInLobby:on_join_request_received(data, peer_name, client_prefe
 	if table.size(data.peers) >= num_player_slots then
 		print("server is full")
 		self:_send_request_denied(sender, 5, my_user_id)
+
 		return
 	end
 
@@ -88,7 +131,7 @@ function HostStateInLobby:on_join_request_received(data, peer_name, client_prefe
 	end
 
 	local new_peer_id, new_peer = nil
-	new_peer_id, new_peer = data.session:add_peer(peer_name, nil, true, false, false, nil, character, sender:ip_at_index(0), xuid, xnaddr)
+	new_peer_id, new_peer = data.session:add_peer(peer_name, nil, true, false, false, nil, character, sender:ip_at_index(0), peer_account_type_str, peer_account_id, xuid, xnaddr)
 
 	if not new_peer_id then
 		print("there was no clean peer_id")
@@ -99,18 +142,24 @@ function HostStateInLobby:on_join_request_received(data, peer_name, client_prefe
 
 	new_peer:set_dlcs(dlcs)
 	new_peer:set_xuid(xuid)
+	new_peer:set_name_drop_in(drop_in_name)
 	new_peer:set_join_attempt_identifier(join_attempt_identifier)
 
 	local new_peer_rpc = nil
-	new_peer_rpc = managers.network:protocol_type() == "TCP_IP" and managers.network:session():resolve_new_peer_rpc(new_peer, sender) or sender
+
+	if sender:protocol_at_index(0) == "TCP_IP" then
+		new_peer_rpc = managers.network:session():resolve_new_peer_rpc(new_peer, sender)
+	else
+		new_peer_rpc = sender
+	end
 
 	new_peer:set_rpc(new_peer_rpc)
 	new_peer:set_ip_verified(true)
 	Network:add_client(new_peer:rpc())
 
 	if not new_peer:begin_ticket_session(auth_ticket) then
-		data.session:remove_peer(new_peer, new_peer:id(), "auth_fail")
 		self:_send_request_denied(sender, 8, my_user_id)
+		data.session:remove_peer(new_peer, new_peer:id(), "auth_fail")
 
 		return
 	end


### PR DESCRIPTION
Update on_join_request_received in session states to align with updated function from U237 Also updated logic in achievement manager. disable_achievements return True if achievement should be disabled, so should be amount of players > 4, not <= 4.

Was only able to get 5 players into a lobby if all players had -steamMM launch parameter. 